### PR TITLE
chore: remove new property defaulty set after upgrading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     'react/jsx-first-prop-new-line': 'off',
     'react/jsx-indent-props': 'off',
     'react/jsx-one-expression-per-line': 'off',
+    'react/jsx-newline': 'off',
     'react/forbid-prop-types': 'off',
     'react/jsx-no-literals': 'off',
     'react/forbid-component-props': 'off',


### PR DESCRIPTION
After upgrading `eslint-plugin-react`, eslint fixers will update your code because of a new default `react/jsx-newline` (cf https://github.com/yannickcr/eslint-plugin-react/commit/8867490f15b7c7d892f6acf9d8be6cba008b9dfb#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10)

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>