### PR TITLE
fix: disable no-leaked-render eslint option for ts eslint

### DIFF
--- a/lib/eslint/eslintrc-typescript.js
+++ b/lib/eslint/eslintrc-typescript.js
@@ -6,6 +6,7 @@ module.exports = {
     'react/jsx-max-depth': 'off',
     'react/display-name': 'off',
     'react/prop-types': 'off',
+    'react/jsx-no-leaked-render': 'off',
     'react/function-component-definition': [
       2,
       { namedComponents: 'arrow-function', unnamedComponents: 'arrow-function' },


### PR DESCRIPTION
As we are in typescript eslint config, disable this, see the link below for more infos.

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md#when-not-to-use-it

Signed-off-by: Paul-Xavier Ceccaldi <pix@wttj.co>